### PR TITLE
Bump dependencies 

### DIFF
--- a/.github/workflows/build-and-test-2.12.yml
+++ b/.github/workflows/build-and-test-2.12.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: 'temurin'

--- a/.github/workflows/build-and-test-2.13.yml
+++ b/.github/workflows/build-and-test-2.13.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: 'temurin'

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -72,7 +72,7 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@ccf74c947955fd1cf117aef6a0e4e66191ef6f61 # v3.25.4
+        uses: github/codeql-action/upload-sarif@b7cec7526559c32f1616476ff32d17ba4c59b2d6 # v3.25.5
         with:
           sarif_file: results.sarif
           category: codacy-${{ matrix.tool }}

--- a/.github/workflows/eclipse-dash.yml
+++ b/.github/workflows/eclipse-dash.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: 'temurin'

--- a/.github/workflows/integration-tests-2.12.yml
+++ b/.github/workflows/integration-tests-2.12.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: 'temurin'

--- a/.github/workflows/integration-tests-2.13.yml
+++ b/.github/workflows/integration-tests-2.13.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: 'temurin'

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: 'temurin'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@ccf74c947955fd1cf117aef6a0e4e66191ef6f61 # v3.25.4
+        uses: github/codeql-action/upload-sarif@b7cec7526559c32f1616476ff32d17ba4c59b2d6 # v3.25.5
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           persist-credentials: false
 

--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -29,6 +29,7 @@ com.google.guava:guava	27.0-jre	compile
 com.google.guava:guava	28.0-jre	compile
 com.google.guava:guava	32.0.0-jre	compile
 com.google.protobuf:protobuf-java	2.5.0	compile
+com.google.protobuf:protobuf-java	3.25.3	compile
 com.google.re2j:re2j	1.1	compile
 com.google.re2j:re2j	1.6	compile
 com.googlecode.concurrent-trees:concurrent-trees	2.6.1	compile
@@ -313,7 +314,7 @@ org.apache.logging.log4j:log4j-core	2.22.1	test
 org.apache.sedona:sedona-common	1.5.0	test
 org.cassandraunit:cassandra-unit	3.7.1.0	test
 org.codehaus.groovy:groovy-jsr223	3.0.20	test
-org.geomesa.testcontainers:testcontainers-accumulo	1.3.0	test
+org.geomesa.testcontainers:testcontainers-accumulo	1.4.0	test
 org.geotools:gt-epsg-hsql	30.2	test
 org.jruby:jruby	9.4.5.0	test
 org.mockito:mockito-core	2.28.2	test

--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -129,10 +129,11 @@ org.apache.accumulo:accumulo-core	2.0.1	compile
 org.apache.accumulo:accumulo-core	2.1.2	compile
 org.apache.accumulo:accumulo-hadoop-mapreduce	2.0.1	compile
 org.apache.accumulo:accumulo-hadoop-mapreduce	2.1.2	compile
-org.apache.arrow:arrow-format	15.0.2	compile
-org.apache.arrow:arrow-memory-core	15.0.2	compile
-org.apache.arrow:arrow-memory-netty	15.0.2	compile
-org.apache.arrow:arrow-vector	15.0.2	compile
+org.apache.arrow:arrow-format	16.1.0	compile
+org.apache.arrow:arrow-memory-core	16.1.0	compile
+org.apache.arrow:arrow-memory-netty	16.1.0	compile
+org.apache.arrow:arrow-memory-netty-buffer-patch	16.1.0	compile
+org.apache.arrow:arrow-vector	16.1.0	compile
 org.apache.avro:avro	1.11.3	compile
 org.apache.commons:commons-collections4	4.4	compile
 org.apache.commons:commons-compress	1.26.0	compile
@@ -188,8 +189,6 @@ org.apiguardian:apiguardian-api	1.1.2	compile
 org.calrissian.mango:mango-core	3.0.0	compile
 org.checkerframework:checker-qual	3.37.0	compile
 org.checkerframework:checker-qual	3.42.0	compile
-org.eclipse.collections:eclipse-collections	11.1.0	compile
-org.eclipse.collections:eclipse-collections-api	11.1.0	compile
 org.eclipse.emf:org.eclipse.emf.common	2.15.0	compile
 org.eclipse.emf:org.eclipse.emf.ecore	2.15.0	compile
 org.eclipse.emf:org.eclipse.emf.ecore.xmi	2.15.0	compile
@@ -302,7 +301,7 @@ com.uber:h3	4.1.1	test
 commons-lang:commons-lang	2.6	test
 junit:junit	4.13.2	test
 org.apache.accumulo:accumulo-test	2.1.2	test
-org.apache.arrow:arrow-vector	tests:15.0.2	test
+org.apache.arrow:arrow-vector	tests:16.1.0	test
 org.apache.cassandra:cassandra-all	3.11.14	test
 org.apache.cassandra:cassandra-thrift	3.11.14	test
 org.apache.curator:curator-test	5.6.0	test

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -90,6 +90,16 @@ Compatibility Matrix
 | Dependencies | N     | N     | Y     |
 +--------------+-------+-------+-------+
 
+Version 5.1.0 Upgrade Guide
++++++++++++++++++++++++++++
+
+Dependency Version Upgrades
+---------------------------
+
+The following dependencies have been upgraded:
+
+* arrow ``15.0.2`` -> ``16.1.0``
+
 Version 5.0.0 Upgrade Guide
 +++++++++++++++++++++++++++
 

--- a/geomesa-convert/geomesa-convert-xml/src/test/scala/org/locationtech/geomesa/convert/xml/XmlConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/test/scala/org/locationtech/geomesa/convert/xml/XmlConverterTest.scala
@@ -670,6 +670,21 @@ class XmlConverterTest extends Specification {
           |    </f:position>
           |  </f:Feature>
           |</f:doc2>
+        """.stripMargin,
+        """<doc3 xmlns="http://geomesa.org/test-feature" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          |  <DataSource>
+          |    <name>myxml</name>
+          |  </DataSource>
+          |  <Feature>
+          |    <number>123</number>
+          |    <color>red</color>
+          |    <physical weight="127.5" height="5'11"/>
+          |    <position>
+          |      <lat>21.1</lat>
+          |      <lon>45.1</lon>
+          |    </position>
+          |  </Feature>
+          |</doc3>
         """.stripMargin
       )
 

--- a/geomesa-hbase/pom.xml
+++ b/geomesa-hbase/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <guava.version>${hbase.guava.version}</guava.version>
         <hadoop.version>${hbase.hadoop.version}</hadoop.version>
+        <protobuf.version>${hbase.protobuf.version}</protobuf.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
         <!-- direct dependencies -->
         <accumulo.access.version>1.0.0-beta</accumulo.access.version>
-        <arrow.version>15.0.2</arrow.version>
+        <arrow.version>16.1.0</arrow.version>
         <avro.version>1.11.3</avro.version>
         <aws.sdk.version>1.12.625</aws.sdk.version>
         <caffeine.version>3.1.8</caffeine.version>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,8 @@
         <hbase.version>2.5.8-hadoop3</hbase.version>
         <hbase.hadoop.version>3.3.6</hbase.hadoop.version>
         <hbase.htrace.version>4.1.0-incubating</hbase.htrace.version>
-        <protobuf.version>2.5.0</protobuf.version> <!-- see also confluent.protobuf.version-->
+        <hbase.protobuf.version>2.5.0</hbase.protobuf.version>
+        <protobuf.version>3.25.3</protobuf.version> <!-- see also confluent.protobuf.version, hbase.protobuf.version -->
         <cassandra.version>3.11.5</cassandra.version>
         <kafka.version>3.7.0</kafka.version> <!-- needs to align with confluent version -->
         <confluent.version>6.2.9</confluent.version> <!-- corresponds to kafka 2.8 - newer versions have license issues, see https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/13628 -->


### PR DESCRIPTION
[GEOMESA-3363 Upgrade to protobuf 3](https://github.com/a0x8o/geomesa/commit/9e94a67322f35a13a38e4ff4b9f0c64aef599197)
[Bump github/codeql-action from 3.25.4 to 3.25.5 (](https://github.com/a0x8o/geomesa/commit/bbed26873070c8312a613f4b6a608f599306738d)https://github.com/locationtech/geomesa/pull/3113[)](https://github.com/a0x8o/geomesa/commit/bbed26873070c8312a613f4b6a608f599306738d) 
Bump actions/checkout from 4.1.5 to 4.1.6 (https://github.com/locationtech/geomesa/pull/3114[)](https://github.com/a0x8o/geomesa/commit/b2ec3911fa931c914ee5681e45faab04fe25c81a) 
GEOMESA-3364 Bump arrow to 16.1.0
[GEOMESA-3361 Xml type inference - support default namespaces (](https://github.com/a0x8o/geomesa/commit/69c374709c4dc96e063530cc2e445569cf811d09)https://github.com/locationtech/geomesa/pull/3111 